### PR TITLE
Calculate cron syntax under the specified time zone

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 Revision history for AnyEvent-Timer-Cron
 
+  - calculate cron syntax under the specified time zone
+
 0.001002 - 2015-06-28
   - correct links in metadata
   - add x_static_install to metadata

--- a/lib/AnyEvent/Timer/Cron.pm
+++ b/lib/AnyEvent/Timer/Cron.pm
@@ -12,6 +12,7 @@ use DateTime::Event::Cron;
 use namespace::clean;
 
 has 'cb' => (is => 'ro', required => 1);
+has 'time_zone' => (is => 'ro');
 has '_cron' => (
     is => 'ro',
     required => 1,
@@ -41,6 +42,7 @@ sub create_timer {
     my $self = shift;
     weaken $self;
     my $now = DateTime->from_epoch(epoch => AnyEvent->now);
+    $now->set_time_zone( $self->time_zone ) if $self->time_zone;
     my $next = $self->next_event($now);
     return
         if not $next;
@@ -57,6 +59,7 @@ sub create_timer {
 sub next_event {
     my $self = shift;
     my $now = shift || DateTime->from_epoch(epoch => AnyEvent->now);
+    $now->set_time_zone( $self->time_zone ) if $self->time_zone;
     $self->_cron->($now);
 }
 
@@ -104,6 +107,10 @@ L<DateTime::Set> object.
 =item cb
 
 Required.  The callback to call for the cron events.
+
+=item time_zone
+
+A cron rule will be calculated under the specified time zone.
 
 =back
 


### PR DESCRIPTION
Current version of this module treats crontab rule as UTC since `DateTime` object doesn't know which time zone is used. So, added `time_zone` attribute and use its value when `DateTime` object is created.

In my case, I use 'Asia/Seoul' time zone which is +0900 and when I use `AnyEvent::Timer::Cron` it treats `00 11 * * *` as 20:00:00 not 11:00:00. This patch helps to use time zone information for users who don't live in UTC time zone.
